### PR TITLE
Switch to route decorators on resource functions

### DIFF
--- a/spritzle/main.py
+++ b/spritzle/main.py
@@ -63,30 +63,11 @@ app = aiohttp.web.Application(
 
 
 def setup_routes():
-    app.router.add_route('POST', '/auth',
-                         spritzle.resource.auth.post_auth)
-    app.router.add_route('GET', '/config',
-                         spritzle.resource.config.get_config)
-    app.router.add_route('PUT', '/config',
-                         spritzle.resource.config.put_config)
-    app.router.add_route('GET', '/session',
-                         spritzle.resource.session.get_session)
-    app.router.add_route('GET', '/session/dht',
-                         spritzle.resource.session.get_session_dht)
-    app.router.add_route('GET', '/settings',
-                         spritzle.resource.settings.get_settings)
-    app.router.add_route('PUT', '/settings',
-                         spritzle.resource.settings.put_settings)
-    app.router.add_route('GET', '/torrent',
-                         spritzle.resource.torrent.get_torrent)
-    app.router.add_route('GET', '/torrent/{tid}',
-                         spritzle.resource.torrent.get_torrent)
-    app.router.add_route('POST', '/torrent',
-                         spritzle.resource.torrent.post_torrent)
-    app.router.add_route('DELETE', '/torrent',
-                         spritzle.resource.torrent.delete_torrent)
-    app.router.add_route('DELETE', '/torrent/{tid}',
-                         spritzle.resource.torrent.delete_torrent)
+    app.router.add_routes(spritzle.resource.auth.routes)
+    app.router.add_routes(spritzle.resource.config.routes)
+    app.router.add_routes(spritzle.resource.session.routes)
+    app.router.add_routes(spritzle.resource.settings.routes)
+    app.router.add_routes(spritzle.resource.torrent.routes)
 
 
 def main():

--- a/spritzle/resource/auth.py
+++ b/spritzle/resource/auth.py
@@ -25,7 +25,10 @@ from datetime import datetime, timedelta
 import jwt
 from aiohttp import web
 
+routes = web.RouteTableDef()
 
+
+@routes.post('/auth')
 async def post_auth(request):
     config = request.app['spritzle.config']
     post = await request.post()

--- a/spritzle/resource/config.py
+++ b/spritzle/resource/config.py
@@ -20,10 +20,16 @@
 #   Boston, MA    02110-1301, USA.
 #
 
+from aiohttp import web
 
+routes = web.RouteTableDef()
+
+
+@routes.get('/config')
 async def get_config(request):
     raise NotImplementedError
 
 
+@routes.put('/config')
 async def put_config(request):
     raise NotImplementedError

--- a/spritzle/resource/session.py
+++ b/spritzle/resource/session.py
@@ -22,13 +22,17 @@
 
 from aiohttp import web
 
+routes = web.RouteTableDef()
 
+
+@routes.get('/session')
 async def get_session(request):
     core = request.app['spritzle.core']
     status = await core.get_session_status()
     return web.json_response(status)
 
 
+@routes.get('/session/dht')
 async def get_session_dht(request):
     core = request.app['spritzle.core']
     return web.json_response(core.session.is_dht_running())

--- a/spritzle/resource/settings.py
+++ b/spritzle/resource/settings.py
@@ -22,12 +22,16 @@
 
 from aiohttp import web
 
+routes = web.RouteTableDef()
 
+
+@routes.get('/settings')
 async def get_settings(request):
     core = request.app['spritzle.core']
     return web.json_response(core.session.get_settings())
 
 
+@routes.put('/settings')
 async def put_settings(request):
     core = request.app['spritzle.core']
     settings = await request.json()

--- a/spritzle/resource/torrent.py
+++ b/spritzle/resource/torrent.py
@@ -33,6 +33,7 @@ import spritzle.common as common
 import libtorrent as lt
 
 log = logging.getLogger('spritzle')
+routes = web.RouteTableDef()
 
 
 def get_valid_handle(core, tid):
@@ -50,6 +51,8 @@ def get_torrent_list(core):
     return [str(th.info_hash()) for th in core.session.get_torrents()]
 
 
+@routes.get('/torrent')
+@routes.get('/torrent/{tid}')
 async def get_torrent(request):
     core = request.app['spritzle.core']
     tid = request.match_info.get('tid', None)
@@ -74,6 +77,7 @@ async def get_torrent(request):
         return web.json_response(status)
 
 
+@routes.post('/torrent')
 async def post_torrent(request):
     """
     libtorrent requires one of these three fields: ti, url, info_hash
@@ -157,6 +161,8 @@ async def post_torrent(request):
         )
 
 
+@routes.delete('/torrent')
+@routes.delete('/torrent/{tid}')
 async def delete_torrent(request):
     core = request.app['spritzle.core']
     tid = request.match_info.get('tid', None)


### PR DESCRIPTION
I think I like the route decorators. This would also allow easily loading all modules from the resources package and registering their routes automatically, though I'm not sure that's really desirable/needed.