### PR TITLE
Add /config tests

### DIFF
--- a/spritzle/resource/config.py
+++ b/spritzle/resource/config.py
@@ -20,6 +20,8 @@
 #   Boston, MA    02110-1301, USA.
 #
 
+from json import JSONDecodeError
+
 from aiohttp import web
 
 routes = web.RouteTableDef()
@@ -34,7 +36,10 @@ async def get_config(request):
 @routes.put('/config')
 async def put_config(request):
     config = request.app['spritzle.config']
-    new_values = await request.json()
+    try:
+        new_values = await request.json()
+    except JSONDecodeError as e:
+        raise web.HTTPBadRequest(text=f'Invalid JSON body: {e}')
     config.data = new_values
     config.save()
     return web.Response()
@@ -43,7 +48,10 @@ async def put_config(request):
 @routes.patch('/config')
 async def patch_config(request):
     config = request.app['spritzle.config']
-    new_values = await request.json()
+    try:
+        new_values = await request.json()
+    except JSONDecodeError as e:
+        raise web.HTTPBadRequest(text=f'Invalid JSON body: {e}')
     config.update(new_values)
     config.save()
     return web.Response()

--- a/spritzle/tests/test_config.py
+++ b/spritzle/tests/test_config.py
@@ -21,21 +21,17 @@
 #
 
 import tempfile
-import os
 import shutil
 from pathlib import Path
+from unittest.mock import patch
 
 from spritzle.config import Config
 
 
 def test_config_init_no_dir():
     tmpdir = Path(tempfile.gettempdir(), 'spritzletmpdir')
-    home = os.environ['HOME']
-    os.environ['HOME'] = str(tmpdir)
-
-    c = Config()
-
-    os.environ['HOME'] = home
+    with patch('pathlib.Path.home', return_value=tmpdir):
+        c = Config()
 
     assert c.config_file == Path(
         tmpdir, '.config', 'spritzle', 'spritzled.conf')


### PR DESCRIPTION
Adds tests for /config resource. fix #7
(I also slipped a Windows fix for the Config class test in, but I think it makes things cleaner on both platforms.)