### PR TITLE
Enable JSON error responses

### DIFF
--- a/spritzle/main.py
+++ b/spritzle/main.py
@@ -69,10 +69,9 @@ async def error_middleware(request, handler):
         tb = ''.join(traceback.format_exception(*sys.exc_info()))
         response = aiohttp.web.Response(status=500, reason='Spritzle Bug',
                                         text=tb)
-    if 200 <= response.status < 300:
+    if response.status < 400:
         return response
     return aiohttp.web.json_response({
-        'error': True,
         'status': response.status,
         'reason': response.reason,
         'message': response.text

--- a/spritzle/main.py
+++ b/spritzle/main.py
@@ -69,7 +69,7 @@ async def error_middleware(request, handler):
         tb = ''.join(traceback.format_exception(*sys.exc_info()))
         response = aiohttp.web.Response(status=500, reason='Spritzle Bug',
                                         text=tb)
-    if response.status == 200:
+    if 200 <= response.status < 300:
         return response
     return aiohttp.web.json_response({
         'error': True,

--- a/spritzle/main.py
+++ b/spritzle/main.py
@@ -26,8 +26,9 @@ import fcntl
 from pathlib import Path
 import secrets
 import sys
+import traceback
 
-import aiohttp
+import aiohttp.web
 
 import spritzle.resource.auth
 import spritzle.resource.config
@@ -40,26 +41,45 @@ from spritzle.config import Config
 from spritzle.logger import setup_logger
 
 
-async def debug_middleware(app, handler):
-    async def middleware(request):
-        if request.content_type in ('application/x-www-form-urlencoded',
-                                    'multipart/form-data'):
-            body = await request.post()
-        else:
-            body = await request.text()
-        log = app['spritzle.log']
-        log.debug('*'*20 + 'REQUEST' + '*'*20)
-        log.debug(f'URL: {request.rel_url}')
-        log.debug(f'METHOD: {request.method}')
-        log.debug(f'HEADERS: {request.headers}')
-        log.debug(f'BODY: {body}')
-        log.debug('*'*47)
-        return await handler(request)
-    return middleware
+@aiohttp.web.middleware
+async def debug_middleware(request, handler):
+    if request.content_type in ('application/x-www-form-urlencoded',
+                                'multipart/form-data'):
+        body = await request.post()
+    else:
+        body = await request.text()
+    log = request.app['spritzle.log']
+    log.debug('*' * 20 + 'REQUEST' + '*' * 20)
+    log.debug(f'URL: {request.rel_url}')
+    log.debug(f'METHOD: {request.method}')
+    log.debug(f'HEADERS: {request.headers}')
+    log.debug(f'BODY: {body}')
+    log.debug('*' * 47)
+    return await handler(request)
 
-app = aiohttp.web.Application(
-    middlewares=[debug_middleware,
-                 spritzle.resource.auth.auth_middleware])
+
+@aiohttp.web.middleware
+async def error_middleware(request, handler):
+    try:
+        response = await handler(request)
+    except aiohttp.web.HTTPException as ex:
+        response = ex
+    except Exception:
+        # Unhandled exception, this is a bug in Spritzle
+        tb = ''.join(traceback.format_exception(*sys.exc_info()))
+        response = aiohttp.web.Response(status=500, reason='Spritzle Bug',
+                                        text=tb)
+    if response.status == 200:
+        return response
+    return aiohttp.web.json_response({
+        'error': True,
+        'status': response.status,
+        'reason': response.reason,
+        'message': response.text
+    }, status=response.status, reason=response.reason)
+
+
+app = aiohttp.web.Application()
 
 
 def setup_app(app, core, log, settings=None):
@@ -70,6 +90,8 @@ def setup_app(app, core, log, settings=None):
     app['spritzle.log'] = log
     app['spritzle.core'] = core
     app['spritzle.config'] = config
+
+    app.middlewares.extend([error_middleware, debug_middleware])
 
     async def on_startup(app):
         await app['spritzle.core'].start(settings=settings)
@@ -115,4 +137,6 @@ def main():
         sys.exit(0)
 
     setup_app(app, Core(config), log)
+    # Auth middleware is outside setup_app because we don't want it for unit tests
+    app.middlewares.append(spritzle.resource.auth.auth_middleware)
     aiohttp.web.run_app(app)

--- a/spritzle/resource/session.py
+++ b/spritzle/resource/session.py
@@ -46,7 +46,7 @@ async def put_session_settings(request):
     try:
         core.session.apply_settings(settings)
     except KeyError as e:
-        raise web.HTTPBadRequest(reason=e)
+        raise web.HTTPBadRequest(reason=str(e))
     return web.json_response()
 
 

--- a/spritzle/tests/resource/test_errors.py
+++ b/spritzle/tests/resource/test_errors.py
@@ -57,14 +57,15 @@ async def test_expected_error(cli, error_params):
     assert response.status == error_params['status']
     assert response.reason == error_params['reason']
     body = await response.json()
-    assert body == {'error': True, **error_params}
+    assert body == error_params
 
 
 async def test_unexpected_error(cli):
     response = await cli.get('/unexpected_error')
     assert response.content_type == 'application/json'
     assert response.status == 500
-    assert 'error' in await response.json()
+    body = await response.json()
+    assert body['status'] == 500
 
 
 async def test_no_error(cli):

--- a/spritzle/tests/resource/test_errors.py
+++ b/spritzle/tests/resource/test_errors.py
@@ -1,0 +1,76 @@
+#
+# test_auth.py
+#
+# Copyright (C) 2016 Andrew Resch <andrewresch@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.    If not, write to:
+#   The Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor
+#   Boston, MA    02110-1301, USA.
+#
+
+import aiohttp.web
+import pytest
+from unittest.mock import patch
+
+
+@pytest.fixture
+def cli(loop, core, app, aiohttp_client):
+    async def get_error(request):
+        # HTTPException doesn't like being instantiated without a status_code
+        with patch('aiohttp.web.HTTPException.status_code', 0):
+            exception = aiohttp.web.HTTPException()
+            exception.set_status(request.query['status'], request.query['reason'])
+            exception.text = request.query['message']
+            raise exception
+
+    async def get_unexpected_error(request):
+        raise Exception()
+
+    async def get_no_error(request):
+        raise aiohttp.web.HTTPOk(text='No Error')
+
+    app.router.add_route('GET', '/expected_error', get_error)
+    app.router.add_route('GET', '/unexpected_error', get_unexpected_error)
+    app.router.add_route('GET', '/no_error', get_no_error)
+    return loop.run_until_complete(aiohttp_client(app))
+
+
+@pytest.mark.parametrize('error_params', [
+    {'status': 404, 'reason': 'not there', 'message': 'aoeu'},
+    {'status': 400, 'reason': 'other thing', 'message': 'blah\nblah'},
+])
+async def test_expected_error(cli, error_params):
+    response = await cli.get('/expected_error', params=error_params)
+    assert response.content_type == 'application/json'
+    assert response.status == error_params['status']
+    assert response.reason == error_params['reason']
+    body = await response.json()
+    assert body == {'error': True, **error_params}
+
+
+async def test_unexpected_error(cli):
+    response = await cli.get('/unexpected_error')
+    assert response.content_type == 'application/json'
+    assert response.status == 500
+    assert 'error' in await response.json()
+
+
+async def test_no_error(cli):
+    """
+    Make sure error handler isn't mangling success responses.
+    """
+    response = await cli.get('/no_error')
+    assert response.content_type == 'text/plain'
+    assert (await response.text()) == 'No Error'


### PR DESCRIPTION
This puts all error responses into a standard JSON format.
Currently that format is:
```json
{
    "error": true,
    "status": "<HTTP status code>",
    "reason": "<HTTP reason string>",
    "message" "<further details>"
}
```
Open to any suggestions on tweaking that format.
Unhandled exceptions are also put into this format, with status code 500, 'Spritzle Bug' reason string, and the traceback as the message.

I also tweaked how middlewares were added, 'debug' and 'error' middleware are now added in `setup_app` so that they apply in unit tests as well as main application. 'auth' middleware was moved to being added in 'main'. Not sure if that's the best way to do it or not.