### PR TITLE
Add some validation when registering alert handlers

### DIFF
--- a/spritzle/tests/test_alert.py
+++ b/spritzle/tests/test_alert.py
@@ -73,6 +73,7 @@ async def test_pop_alerts(monkeypatch):
     monkeypatch.setattr('libtorrent.alert.category_t', CategoryT)
     a = spritzle.alert.Alert()
     a.session = session
+    a.alert_types = ['AlertTestOne', 'AlertTestTwo', 'AlertTestThree']
 
     handler_one = asynctest.CoroutineMock()
     a.register_handler('AlertTestOne', handler_one)

--- a/spritzle/tests/test_alert.py
+++ b/spritzle/tests/test_alert.py
@@ -21,7 +21,9 @@
 #
 
 from unittest.mock import MagicMock
+
 import asynctest
+import pytest
 
 import spritzle.alert
 
@@ -92,3 +94,23 @@ async def test_pop_alerts(monkeypatch):
     handler_one.assert_called_with(alert_test_one)
     handler_two.assert_called_with(alert_test_two)
     handler_three.assert_called_with(alert_test_one)
+
+
+def test_handler_validation(monkeypatch):
+    async def valid_handler(alert):
+        pass
+
+    def invalid_handler(alert):
+        pass
+
+    a = spritzle.alert.Alert()
+
+    # Verify a valid handler doesn't raise anything
+    a.register_handler('torrent_paused_alert', valid_handler)
+    a.register_handler('storage_notification', valid_handler)
+
+    with pytest.raises(ValueError):
+        a.register_handler('torrent_paused_alert', invalid_handler)
+
+    with pytest.raises(ValueError):
+        a.register_handler('not an alert type', valid_handler)


### PR DESCRIPTION
I was getting some exceptions by accidentally adding non async functions as handlers for alerts. This would stop the alert manager without printing any tracebacks because the `pop_alerts` task was never awaited. This adds some validation to make sure alert handlers are actually coroutine functions, as well as checking a valid alert type or category was specified.