### PR TITLE
Small tweaks

### DIFF
--- a/spritzle/core.py
+++ b/spritzle/core.py
@@ -143,4 +143,4 @@ class Core(object):
 
     async def on_state_changed_alert(self, alert):
         if alert.handle.need_save_resume_data():
-            alert.handle.save_resume_data()
+            self.resume_data.save_torrent(alert.handle)

--- a/spritzle/tests/test_alert.py
+++ b/spritzle/tests/test_alert.py
@@ -104,13 +104,16 @@ def test_handler_validation(monkeypatch):
         pass
 
     a = spritzle.alert.Alert()
+    valid_alert_type = 'torrent_paused_alert'
+    valid_category = 'storage_notification'
+    invalid_alert_type = 'invalid_alert_type'
 
     # Verify a valid handler doesn't raise anything
-    a.register_handler('torrent_paused_alert', valid_handler)
-    a.register_handler('storage_notification', valid_handler)
+    a.register_handler(valid_alert_type, valid_handler)
+    a.register_handler(valid_category, valid_handler)
 
     with pytest.raises(ValueError):
-        a.register_handler('torrent_paused_alert', invalid_handler)
+        a.register_handler(valid_alert_type, invalid_handler)
 
     with pytest.raises(ValueError):
-        a.register_handler('not an alert type', valid_handler)
+        a.register_handler(invalid_alert_type, valid_handler)

--- a/spritzle/tests/test_alert.py
+++ b/spritzle/tests/test_alert.py
@@ -96,7 +96,7 @@ async def test_pop_alerts(monkeypatch):
     handler_three.assert_called_with(alert_test_one)
 
 
-def test_handler_validation(monkeypatch):
+async def test_handler_validation():
     async def valid_handler(alert):
         pass
 


### PR DESCRIPTION
Addresses two small things:
- Switches over a core call to use the resume data manager rather than raw libtorrent call
- Alert handler validation test messed up when run with more tests, because a new asyncio loop wouldn't be installed. Remedy that by making it a coroutine function.
- Updates the alert handler validation tests to make the intent clearer, and easier to update if categories/alert types change in libtorrent