### PR TITLE
Switch to create_task from ensure_future, when operation on known coroutines

### DIFF
--- a/spritzle/alert.py
+++ b/spritzle/alert.py
@@ -101,7 +101,7 @@ class Alert(object):
                 if not (self.run or run_once):
                     break
 
-                futures = []
+                tasks = []
                 for alert in self.session.pop_alerts():
                     handlers = set()
                     handlers.update(self.handlers.get(alert.what(), []))
@@ -110,12 +110,12 @@ class Alert(object):
                         if alert.category() & v:
                             handlers.update(self.handlers.get(k, []))
                     for handler in handlers:
-                        futures.append(self.loop.create_task(handler(alert)))
+                        tasks.append(self.loop.create_task(handler(alert)))
 
                 # We have to make sure all alert handlers have completed before
                 # calling pop_alerts() again as it will invalidate all previous
                 # libtorrent alert objects.
-                await asyncio.gather(*futures)
+                await asyncio.gather(*tasks)
 
             if run_once:
                 break

--- a/spritzle/alert.py
+++ b/spritzle/alert.py
@@ -78,7 +78,7 @@ class Alert(object):
         log.debug('Alert starting..')
         self.session = session
         self.run = True
-        self.pop_alerts_task = asyncio.ensure_future(self.pop_alerts())
+        self.pop_alerts_task = self.loop.create_task(self.pop_alerts())
 
     async def stop(self):
         log.debug('Alert stopping..')
@@ -110,7 +110,7 @@ class Alert(object):
                         if alert.category() & v:
                             handlers.update(self.handlers.get(k, []))
                     for handler in handlers:
-                        futures.append(asyncio.ensure_future(handler(alert)))
+                        futures.append(self.loop.create_task(handler(alert)))
 
                 # We have to make sure all alert handlers have completed before
                 # calling pop_alerts() again as it will invalidate all previous

--- a/spritzle/hooks.py
+++ b/spritzle/hooks.py
@@ -61,4 +61,4 @@ class Hooks:
 
     def run_hooks(self, hook_name, *args):
         for hook in self.find_hooks(hook_name):
-            asyncio.ensure_future(self.run_hook(hook, *args))
+            asyncio.get_event_loop().create_task(self.run_hook(hook, *args))

--- a/spritzle/resume_data.py
+++ b/spritzle/resume_data.py
@@ -51,7 +51,7 @@ class ResumeData(object):
             'save_resume_data_failed_alert',
             self.on_save_resume_data_failed_alert
         )
-        self.save_loop_task = asyncio.ensure_future(self.save_loop())
+        self.save_loop_task = self.loop.create_task(self.save_loop())
 
     async def stop(self):
         log.debug("Resume data manager stopping...")
@@ -68,7 +68,7 @@ class ResumeData(object):
                 await asyncio.sleep(
                     self.core.config['resume_data_save_frequency'])
                 # Don't interrupt save process when loop is cancelled
-                save_fut = asyncio.ensure_future(self.save_all())
+                save_fut = self.loop.create_task(self.save_all())
                 await asyncio.shield(save_fut)
         except asyncio.CancelledError:
             if save_fut and not save_fut.done():

--- a/spritzle/resume_data.py
+++ b/spritzle/resume_data.py
@@ -62,17 +62,17 @@ class ResumeData(object):
         log.debug("Resume data manager stopped.")
 
     async def save_loop(self):
-        save_fut = None
+        save_all_task = None
         try:
             while True:
                 await asyncio.sleep(
                     self.core.config['resume_data_save_frequency'])
                 # Don't interrupt save process when loop is cancelled
-                save_fut = self.loop.create_task(self.save_all())
-                await asyncio.shield(save_fut)
+                save_all_task = self.loop.create_task(self.save_all())
+                await asyncio.shield(save_all_task)
         except asyncio.CancelledError:
-            if save_fut and not save_fut.done():
-                await save_fut
+            if save_all_task and not save_all_task.done():
+                await save_all_task
 
     async def on_save_resume_data_alert(self, alert):
         info_hash = str(alert.handle.info_hash())


### PR DESCRIPTION
This explicitly calls loop.create_task to schedule coroutines where needed. I think the wording clarifies what is happening a bit when reading through code.

Based on notes from https://github.com/python/asyncio/issues/477#issuecomment-268709555, ensure_future is meant to be a compatibility layer, only needed when input might already be a future, or a coroutine.