### PR TITLE
[WIP] Torrent actions

### DIFF
--- a/spritzle/resource/torrent.py
+++ b/spritzle/resource/torrent.py
@@ -169,13 +169,35 @@ async def post_torrent(request):
     )
 
 
-@routes.get('/torrent/{tid}/{method}')
+UNSUPPORTED_METHODS = [
+    'read_piece',
+    'get_peer_info',
+    'status',
+    'get_download_queue',
+    'file_progress',
+    'file_status',
+    'add_tracker',
+    'replace_trackers',
+    'trackers',
+    'url_seeds',
+    'add_extension',
+    'save_resume_data',
+    'piece_availability',
+    'move_storage',
+    'rename_file',
+    'native_handle'
+]
+
 @routes.post('/torrent/{tid}/{method}')
 async def get_post_torrent_method(request):
+
     core = request.app['spritzle.core']
     tid = request.match_info.get('tid')
     method_name = request.match_info.get('method')
     handle = get_valid_handle(core, tid)
+
+    if method_name in UNSUPPORTED_METHODS:
+        raise web.HTTPBadRequest(reason=f'Spritzle does not (yet) support the {method_name} method.')
 
     body = await request.text()
     if body:

--- a/spritzle/resource/torrent.py
+++ b/spritzle/resource/torrent.py
@@ -179,7 +179,12 @@ async def get_post_torrent_method(request):
 
     body = await request.text()
     if body:
-        args = json.loads(body)
+        try:
+            args = json.loads(body)
+        except JSONDecodeError as ex:
+            raise web.HTTPBadRequest(reason='Invalid JSON', text=ex.msg)
+        if not isinstance(args, list):
+            raise web.HTTPBadRequest(reason='Body must be a list of arguments.')
     else:
         args = []
 

--- a/spritzle/resource/torrent.py
+++ b/spritzle/resource/torrent.py
@@ -180,13 +180,19 @@ UNSUPPORTED_METHODS = [
     'replace_trackers',
     'trackers',
     'url_seeds',
+    'add_url_seed',
+    'remove_url_seed',
+    'http_seeds',
+    'add_http_seed',
+    'remove_http_seed',
     'add_extension',
     'save_resume_data',
     'piece_availability',
     'move_storage',
     'rename_file',
-    'native_handle'
+    'native_handle',
 ]
+
 
 @routes.post('/torrent/{tid}/{method}')
 async def get_post_torrent_method(request):

--- a/spritzle/resource/torrent.py
+++ b/spritzle/resource/torrent.py
@@ -182,8 +182,13 @@ async def post_torrent_action(request):
     if not method or not callable(method):
         raise web.HTTPBadRequest(reason=f"Invalid action '{body['action']}'")
 
+    args = []
+    if 'args' in body:
+        args = body['args']
+    elif 'arg' in body:
+        args.append(body['arg'])
     try:
-        method(*body.get('args', []))
+        method(*args)
     except Exception as ex:
         raise web.HTTPBadRequest(text=f'Something went wrong: {ex}')
 

--- a/spritzle/resource/torrent.py
+++ b/spritzle/resource/torrent.py
@@ -205,6 +205,10 @@ async def get_post_torrent_method(request):
     if method_name in UNSUPPORTED_METHODS:
         raise web.HTTPBadRequest(reason=f'Spritzle does not (yet) support the {method_name} method.')
 
+    method = getattr(handle, method_name, None)
+    if not method or not callable(method) or method_name.startswith('_'):
+        raise web.HTTPBadRequest(reason=f"Invalid method '{method_name}'")
+
     body = await request.text()
     if body:
         try:
@@ -215,10 +219,6 @@ async def get_post_torrent_method(request):
             raise web.HTTPBadRequest(reason='Body must be a list of arguments.')
     else:
         args = []
-
-    method = getattr(handle, method_name, None)
-    if not method or not callable(method):
-        raise web.HTTPBadRequest(reason=f"Invalid method '{method_name}'")
 
     try:
         result = method(*args)

--- a/spritzle/tests/resource/test_torrent.py
+++ b/spritzle/tests/resource/test_torrent.py
@@ -221,3 +221,17 @@ async def test_edit_queue_position(cli):
     r = await cli.get(f'/torrent/{t1_id}')
     status = await r.json()
     assert status['queue_position'] == 0
+
+
+async def test_set_torrent_priority(cli):
+    tid = await test_post_torrent(cli)
+
+    await cli.post(f'/torrent/{tid}', json={'action': 'set_priority', 'arg': 10})
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert status['priority'] == 10
+
+    await cli.post(f'/torrent/{tid}', json={'action': 'set_priority', 'arg': 255})
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert status['priority'] == 255

--- a/spritzle/tests/resource/test_torrent.py
+++ b/spritzle/tests/resource/test_torrent.py
@@ -237,22 +237,6 @@ async def test_set_torrent_priority(cli):
     assert status['priority'] == 255
 
 
-async def test_torrent_trackers(cli):
-    tid = await test_post_torrent(cli)
-    tracker_url = 'http://localhost'
-    tracker_tier = 0
-
-    r = await cli.get(f'/torrent/{tid}/trackers')
-    trackers = await r.json()
-    assert trackers == []
-
-    await cli.post(f'/torrent/{tid}/add_tracker', json=[{'url': tracker_url, 'tier': tracker_tier}])
-    r = await cli.get(f'/torrent/{tid}/trackers')
-    trackers = await r.json()
-    assert trackers[0]['url'] == tracker_url
-    assert trackers[0]['tier'] == tracker_tier
-
-
 async def test_set_auto_managed(cli):
     tid = await test_post_torrent(cli)
 

--- a/spritzle/tests/resource/test_torrent.py
+++ b/spritzle/tests/resource/test_torrent.py
@@ -251,3 +251,21 @@ async def test_torrent_trackers(cli):
     trackers = await r.json()
     assert trackers[0]['url'] == tracker_url
     assert trackers[0]['tier'] == tracker_tier
+
+
+async def test_set_auto_managed(cli):
+    tid = await test_post_torrent(cli)
+
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert not status['auto_managed']
+
+    await cli.post(f'/torrent/{tid}/auto_managed', json=[True])
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert status['auto_managed']
+
+    await cli.post(f'/torrent/{tid}/auto_managed', json=[False])
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert not status['auto_managed']

--- a/spritzle/tests/resource/test_torrent.py
+++ b/spritzle/tests/resource/test_torrent.py
@@ -166,14 +166,14 @@ async def test_pause_resume_torrent(cli):
 
     response = await cli.get(f'/torrent/{tid}')
     data = await response.json()
-    assert data['paused'] == True
+    assert data['paused']
 
     await cli.post(f'/torrent/{tid}', json={'action': 'resume'})
     response = await cli.get(f'/torrent/{tid}')
     data = await response.json()
-    assert data['paused'] == False
+    assert not data['paused']
 
     await cli.post(f'/torrent/{tid}', json={'action': 'pause'})
     response = await cli.get(f'/torrent/{tid}')
     data = await response.json()
-    assert data['paused'] == True
+    assert data['paused']

--- a/spritzle/tests/resource/test_torrent.py
+++ b/spritzle/tests/resource/test_torrent.py
@@ -19,7 +19,7 @@
 #   51 Franklin Street, Fifth Floor
 #   Boston, MA    02110-1301, USA.
 #
-
+import asyncio
 from base64 import b64encode
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -253,3 +253,72 @@ async def test_set_auto_managed(cli):
     r = await cli.get(f'/torrent/{tid}')
     status = await r.json()
     assert not status['auto_managed']
+
+
+async def test_set_upload_mode(cli):
+    tid = await test_post_torrent(cli)
+
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert not status['upload_mode']
+
+    await cli.post(f'/torrent/{tid}/set_upload_mode', json=[True])
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert status['upload_mode']
+
+    await cli.post(f'/torrent/{tid}/set_upload_mode', json=[False])
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert not status['upload_mode']
+
+
+async def test_set_share_mode(cli):
+    tid = await test_post_torrent(cli)
+
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert not status['share_mode']
+
+    await cli.post(f'/torrent/{tid}/set_share_mode', json=[True])
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert status['share_mode']
+
+    await cli.post(f'/torrent/{tid}/set_share_mode', json=[False])
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert not status['share_mode']
+
+
+async def test_apply_ip_filter(cli):
+    tid = await test_post_torrent(cli)
+
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert not status['ip_filter_applies']
+
+    await cli.post(f'/torrent/{tid}/apply_ip_filter', json=[True])
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert status['ip_filter_applies']
+
+    await cli.post(f'/torrent/{tid}/apply_ip_filter', json=[False])
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert not status['ip_filter_applies']
+
+
+async def test_force_recheck(cli):
+    tid = await test_post_torrent(cli)
+    await asyncio.sleep(1)
+
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert status['state'] != 'checking_resume_data'
+
+    await cli.post(f'/torrent/{tid}/force_recheck')
+
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert status['state'] == 'checking_resume_data'

--- a/spritzle/tests/resource/test_torrent.py
+++ b/spritzle/tests/resource/test_torrent.py
@@ -281,3 +281,17 @@ async def test_force_recheck(cli):
     r = await cli.get(f'/torrent/{tid}')
     status = await r.json()
     assert status['state'] == 'checking_resume_data'
+
+
+async def test_set_max_uploads(cli):
+    tid = await test_post_torrent(cli)
+
+    await cli.post(f'/torrent/{tid}/set_max_uploads', json=[10])
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert status['uploads_limit'] == 10
+
+    await cli.post(f'/torrent/{tid}/set_max_uploads', json=[255])
+    r = await cli.get(f'/torrent/{tid}')
+    status = await r.json()
+    assert status['uploads_limit'] == 255

--- a/spritzle/tests/torrents/testtorrent1.torrent
+++ b/spritzle/tests/torrents/testtorrent1.torrent
@@ -1,0 +1,1 @@
+d13:creation datei1526572403e4:infod6:lengthi1e4:name9:file1.txt12:piece lengthi16384e6:pieces20:5j+y°LTWMÂFæ9T(«ee

--- a/spritzle/tests/torrents/testtorrent2.torrent
+++ b/spritzle/tests/torrents/testtorrent2.torrent
@@ -1,0 +1,1 @@
+d13:creation datei1526572434e4:infod6:lengthi1e4:name9:file2.txt12:piece lengthi16384e6:pieces20:ÚK’7ºÌÍñœ`Ê·®Ä¨5°ee

--- a/spritzle/tests/torrents/testtorrent3.torrent
+++ b/spritzle/tests/torrents/testtorrent3.torrent
@@ -1,0 +1,1 @@
+d13:creation datei1526575544e4:infod6:lengthi1e4:name9:file3.txt12:piece lengthi16384e6:pieces20:wŞhÚìØ#º»µÛ×nƒ»ee


### PR DESCRIPTION
Add ability to do actions on torrents (#22.)

This takes the form of a POST to `/torrent/{tid}/{torrent_handle_method}`. The json body can contain a list, which will be applied as arguments to the method call.

Currently tested:
- pause/resume
- queue_position_up/down/top/bottom
- set_priority
- trackers/add_tracker

TODO:
- [ ] Docs
- [x] Consider whether this is a nice interface
- [x] Consider GET vs POST handling. (right now the two are interchangeable for all methods)
- [ ] Check we have all appropriate error handling and reporting
- [ ] Test more actions
- [ ] Special case actions that require waiting for alerts in `core.torrent`
  - [ ] move_storage
  - [ ] rename_file
  - [ ] scrape_tracker?
- [ ] more?


| Method | Tested | Excluded | Comment |
| --- | --- | --- | --- |
| add_http_seed |   | x |  |
| add_piece |   |   |  |
| add_tracker |   | x |  |
| add_url_seed |   | x |  |
| apply_ip_filter | x |   |  |
| auto_managed | x |   |  |
| clear_error |   |   |  |
| clear_piece_deadlines |   |   |  |
| connect_peer |   |   |  |
| download_limit |   |   |  |
| file_priorities |   |   |  |
| file_priority |   |   |  |
| file_progress |   | x |  |
| file_status |   | x |  |
| flags |   |   | In status dict. |
| flush_cache |   |   |  |
| force_dht_announce |   |   |  |
| force_reannounce |   |   |  |
| force_recheck | x |   |  |
| get_download_queue |   | x |  |
| get_file_priorities |   |   |  |
| get_peer_info |   | x |  |
| get_piece_priorities |   |   |  |
| get_torrent_info |   |   |  |
| has_metadata |   |   |  |
| have_piece |   |   |  |
| http_seeds |   | x |  |
| info_hash |   |   |  |
| is_auto_managed |   |   |  |
| is_finished |   |   | In status dict. |
| is_paused |   |   | In status dict. |
| is_seed |   |   |  |
| is_valid |   |   |  |
| max_connections |   |   |  |
| max_uploads |   |   | In status dict. |
| move_storage |   | x |  |
| name |   |   | In status dict. |
| need_save_resume_data |   |   |  |
| pause | x |   |  |
| piece_availability |   | x |  |
| piece_priorities |   |   |  |
| piece_priority |   |   |  |
| prioritize_files |   |   |  |
| prioritize_pieces |   |   |  |
| queue_position |   |   | In status dict. |
| queue_position_bottom | x |   |  |
| queue_position_down | x |   |  |
| queue_position_top | x |   |  |
| queue_position_up | x |   |  |
| read_piece |   | x |  |
| remove_http_seed |   | x |  |
| remove_url_seed |   | x |  |
| rename_file |   | x |  |
| replace_trackers |   | x |  |
| reset_piece_deadline |   |   |  |
| resume | x |   |  |
| save_path |   |   | In status dict. |
| save_resume_data |   | x |  |
| scrape_tracker |   |   |  |
| set_download_limit |   |   |  |
| set_flags |   |   |  |
| set_max_connections |   |   |  |
| set_max_uploads | x |   |  |
| set_metadata |   |   |  |
| set_peer_download_limit |   |   |  |
| set_peer_upload_limit |   |   |  |
| set_piece_deadline |   |   |  |
| set_priority | x |   |  |
| set_ratio |   |   |  |
| set_sequential_download |   |   |  |
| set_share_mode | x |   |  |
| set_ssl_certificate |   |   |  |
| set_tracker_login |   |   |  |
| set_upload_limit |   |   |  |
| set_upload_mode | x |   |  |
| status |   | x |  |
| stop_when_ready | x |   |  |
| super_seeding |   |   |  |
| torrent_file |   |   |  |
| trackers |   | x |  |
| unset_flags |   |   |  |
| upload_limit |   |   |  |
| url_seeds |   | x |  |
| use_interface |   |   |  |
| write_resume_data |   |   |  |